### PR TITLE
Remove empty entries when splitting strings into array

### DIFF
--- a/src/JasperFx.Core.Tests/StringExtensionsTester.cs
+++ b/src/JasperFx.Core.Tests/StringExtensionsTester.cs
@@ -335,6 +335,20 @@ e
     {
         one.EndsWithIgnoreCase(suffix).ShouldBe(expected);
     }
+
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("foo=bar", 1)]
+    [InlineData("foo=bar;", 1)]
+    [InlineData("foo=bar;zap=42;", 2)]
+    [InlineData("foo=bar;zap=42", 2)]
+    public void removes_empty_entries_when_splitting_strings_into_array(string one, int expectedCount)
+    {
+        var array = one.ToDelimitedArray(';');
+
+        array.Length.ShouldBe(expectedCount);
+        array.All(x => x.IsNotEmpty()).ShouldBeTrue();
+    }
 }
 
 public enum EnvTarget

--- a/src/JasperFx.Core/StringExtensions.cs
+++ b/src/JasperFx.Core/StringExtensions.cs
@@ -225,26 +225,22 @@ public static class StringExtensions
     /// </summary>
     /// <param name="content"></param>
     /// <returns></returns>
+    /// <remarks>Empty entries are omitted</remarks>
     public static string[] ToDelimitedArray(this string content)
     {
         return content.ToDelimitedArray(',');
     }
 
     /// <summary>
-    /// 
+    /// Break a comma delimited string into an array of trimmed strings
     /// </summary>
     /// <param name="content"></param>
     /// <param name="delimiter"></param>
     /// <returns></returns>
+    /// <remarks>Empty entries are omitted</remarks>
     public static string[] ToDelimitedArray(this string content, char delimiter)
     {
-        string[] array = content.Split(delimiter);
-        for (int i = 0; i < array.Length; i++)
-        {
-            array[i] = array[i].Trim();
-        }
-
-        return array;
+        return content.Split(delimiter, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
     public static bool IsValidNumber(this string number)


### PR DESCRIPTION
I believe no downstream code is interested in empty entries.

In the meantime, without this behaviour, the RabbitMQ configuration in Wolverine fails at runtime if the connection string contains a trailing comma. See https://github.com/JasperFx/wolverine/pull/875.

The above downstream pull request can be closed if this change is accepted.